### PR TITLE
fix: `ble_scan_android`  hot fix scanning mode, location services in android platfrom

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -26,6 +26,9 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
   - Flutter (1.0.0)
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
   - google_ml_kit (0.6.0):
     - Flutter
     - GoogleMLKit/BarcodeScanning (~> 2.2.0)
@@ -184,6 +187,8 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
+  - path_provider_ios (0.0.1):
+    - Flutter
   - "permission_handler (5.1.0+2)":
     - Flutter
   - PromisesObjC (2.0.0)
@@ -195,6 +200,9 @@ PODS:
     - SwiftProtobuf (~> 1.0)
   - shared_preferences_ios (0.0.1):
     - Flutter
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
   - SSZipArchive (2.4.3)
   - SwiftProtobuf (1.18.0)
   - TensorFlowLiteC (2.7.0):
@@ -214,9 +222,11 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
   - google_ml_kit (from `.symlinks/plugins/google_ml_kit/ios`)
+  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
   - reactive_ble_mobile (from `.symlinks/plugins/reactive_ble_mobile/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - tflite (from `.symlinks/plugins/tflite/ios`)
 
 SPEC REPOS:
@@ -225,6 +235,7 @@ SPEC REPOS:
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseInstallations
+    - FMDB
     - GoogleDataTransport
     - GoogleMLKit
     - GoogleToolboxForMac
@@ -272,12 +283,16 @@ EXTERNAL SOURCES:
     :path: Flutter
   google_ml_kit:
     :path: ".symlinks/plugins/google_ml_kit/ios"
+  path_provider_ios:
+    :path: ".symlinks/plugins/path_provider_ios/ios"
   permission_handler:
     :path: ".symlinks/plugins/permission_handler/ios"
   reactive_ble_mobile:
     :path: ".symlinks/plugins/reactive_ble_mobile/ios"
   shared_preferences_ios:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
   tflite:
     :path: ".symlinks/plugins/tflite/ios"
 
@@ -291,6 +306,7 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: c2836d254a8f0bbb4121ff18f2c2ea39d118fd08
   FirebaseInstallations: 60edbf7e11d91ae4c751d26c200dfd037099abe0
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   google_ml_kit: a85eefb9ea6156b27ee2fba2b71e461e7b26a4f6
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleMLKit: 85ffdc9641d05311c76dbba5bbf93059087be12f
@@ -319,12 +335,14 @@ SPEC CHECKSUMS:
   MLKitVisionKit: 226bac429eda1d84285409e31ce9da72606850fb
   MLKitXenoCommon: bf5b3528d77cabe0d04f3c13536ba1302346e31c
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
+  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 0ac2cdc92fb5c33dab66dd1c4e9f9cc4c34d00ba
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   reactive_ble_mobile: 9ce6723d37ccf701dbffd202d487f23f5de03b4c
   shared_preferences_ios: aef470a42dc4675a1cdd50e3158b42e3d1232b32
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
   SwiftProtobuf: c3c12645230d9b09c72267e0de89468c5543bd86
   TensorFlowLiteC: 50d75ed3640c15dcfbaf88ca4326297b445e00a1

--- a/lib/blocs/ble_scan/bloc/ble_scan_bloc.dart
+++ b/lib/blocs/ble_scan/bloc/ble_scan_bloc.dart
@@ -27,7 +27,10 @@ class BleScanBloc extends Bloc<BleScanEvent, BleScanState> {
     try {
       emitter(BleScanState.load());
       scanSubscription = repository.ble
-          .scanForDevices(withServices: ble_constants.deviceServices)
+          .scanForDevices(
+              withServices: ble_constants.deviceServices,
+              scanMode: ScanMode.lowLatency,
+              requireLocationServicesEnabled: false)
           .listen((data) {
         if (data.name == ble_constants.DEVICE_NAME) {
           device = data;

--- a/lib/services/tensorflow_service/qr_code_service.dart
+++ b/lib/services/tensorflow_service/qr_code_service.dart
@@ -20,7 +20,7 @@ class GoogleMLKitQRService extends ITensorFlowCommon<InputImage, String> {
     var qrRecognitions = await _barcodeScanner.processImage(data);
     for (var element in qrRecognitions) {
       sink.add(element.value.rawValue!);
-      // print(element.value.rawValue);
+      print(element.value.rawValue);
     }
     isBusy = false;
     return;

--- a/lib/widgets/confirm/organization_confirm.dart
+++ b/lib/widgets/confirm/organization_confirm.dart
@@ -1,15 +1,18 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_localization/src/public_ext.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gateway/config/themes/gateway_color.dart';
 import 'package:gateway/generated/locale_keys.g.dart';
 import 'package:gateway/model/organization_info.dart';
+import 'package:shimmer/shimmer.dart';
 
 class OrganizationConfirm extends StatefulWidget {
-  const OrganizationConfirm({Key? key, 
-  required this.organizationInfo, 
-  required this.callBack, 
- }) : super(key: key);
+  const OrganizationConfirm({
+    Key? key,
+    required this.organizationInfo,
+    required this.callBack,
+  }) : super(key: key);
   final Function callBack;
   final OrganizationInfo organizationInfo;
 
@@ -26,9 +29,19 @@ class _OrganizationConfirmState extends State<OrganizationConfirm> {
         SizedBox(
           width: 277.w,
           height: 138.h,
-          child: Image.network(
-            widget.organizationInfo.imageUrl.toString(),
+          child: CachedNetworkImage(
+            imageUrl: widget.organizationInfo.imageUrl.toString(),
             fit: BoxFit.cover,
+            placeholder: (context, url) {
+              return Shimmer.fromColors(
+                baseColor: Colors.grey[300]!,
+                highlightColor: Colors.grey[100]!,
+                child: Container(
+                  width: 277.w,
+                  height: 138.h,
+                ),
+              );
+            },
           ),
         ),
         Padding(
@@ -79,40 +92,41 @@ class _OrganizationConfirmState extends State<OrganizationConfirm> {
                 ],
               ),
               SizedBox(height: 24.h),
-              thisOrganization ?
-              Align(
-                alignment: Alignment.bottomRight,
-                child: InkWell(
-                  onTap: () {
-                    widget.callBack();
-                    setState(() {
-                      thisOrganization = !thisOrganization;
-                    });
-                  },
-                  child: Container(
-                    width: 186.w,
-                    height: 36.h,
-                    decoration: BoxDecoration(
-                      color: GatewayColors.bgButtonColorHaveBorder,
-                      borderRadius: BorderRadius.circular(8.r),
-                      border: Border.all(
-                        color: GatewayColors.buttonBgLight,
-                        width: 1.h,
-                      ),
-                    ),
-                    child: Center(
-                      child: Text(
-                        LocaleKeys.this_is_my_organization.tr(),
-                        style: TextStyle(
-                          color: Colors.black87,
-                          fontSize: 13.sp,
-                          fontWeight: FontWeight.w400,
+              thisOrganization
+                  ? Align(
+                      alignment: Alignment.bottomRight,
+                      child: InkWell(
+                        onTap: () {
+                          widget.callBack();
+                          setState(() {
+                            thisOrganization = !thisOrganization;
+                          });
+                        },
+                        child: Container(
+                          width: 186.w,
+                          height: 36.h,
+                          decoration: BoxDecoration(
+                            color: GatewayColors.bgButtonColorHaveBorder,
+                            borderRadius: BorderRadius.circular(8.r),
+                            border: Border.all(
+                              color: GatewayColors.buttonBgLight,
+                              width: 1.h,
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              LocaleKeys.this_is_my_organization.tr(),
+                              style: TextStyle(
+                                color: Colors.black87,
+                                fontSize: 13.sp,
+                                fontWeight: FontWeight.w400,
+                              ),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                  ),
-                ),
-              ): Container(),
+                    )
+                  : Container(),
             ],
           ),
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.1.4"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.0"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   camera:
     dependency: "direct main"
     description:
@@ -391,6 +412,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.0.1"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.4"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.3.0"
   flutter_launcher_icons:
     dependency: "direct main"
     description:
@@ -609,6 +644,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   overlay_dialog:
     dependency: "direct main"
     description:
@@ -630,6 +672,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.12"
+  path_provider_ios:
+    dependency: transitive
+    description:
+      name: path_provider_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
   path_provider_linux:
     dependency: transitive
     description:
@@ -637,6 +700,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -651,6 +721,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   permission_handler:
     dependency: "direct main"
     description:
@@ -847,6 +924,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -880,6 +964,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   stack_trace:
     dependency: transitive
     description:
@@ -908,6 +1006,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   term_glyph:
     dependency: transitive
     description:
@@ -966,6 +1071,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.4"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.6"
   vector_math:
     dependency: transitive
     description:
@@ -1030,5 +1142,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=2.16.0 <3.0.0"
+  flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,9 @@ dependencies:
   device_info_plus: ^3.2.2
   overlay_dialog: ^0.2.1
   flutter_launcher_icons: ^0.9.2
+  cached_network_image: ^3.2.0
+  path_provider: ^2.0.9
+  shimmer: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
https://github.com/PhilipsHue/flutter_reactive_ble
https://github.com/PhilipsHue/flutter_reactive_ble/issues/87
docs
#### flutter_reactive_ble README for android

Scan for BLE peripherals advertising the services specified in [withServices] or for all BLE peripherals, if no services is specified. It is recommended to always specify some services.

There are two Android specific parameters that are ignored on iOS:

[scanMode] allows to choose between different levels of power efficient and/or low latency scan modes.
[requireLocationServicesEnabled] specifies whether to check if location services are enabled before scanning. When set to true and location services are disabled, an exception is thrown. Default is true. Setting the value to false can result in not finding BLE peripherals on some Android devices.